### PR TITLE
Added request optional parameter functionality

### DIFF
--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -6,9 +6,18 @@ use OpenCage\Geocoder\AbstractGeocoder;
 
 class Geocoder extends AbstractGeocoder
 {
-    public function geocode($query)
+    public function geocode($query, $optParams = [])
     {
         $url = self::URL . 'q=' . urlencode($query);
+        
+        if(is_array($optParams) && !empty($optParams))
+        {
+            foreach($optParams as $param => $paramValue)
+            {
+                $url .= '&'.$param.'=' . urlencode($paramValue);
+            }
+        }
+        
         if (empty($this->key)) {
             throw new \Exception('Missing API key');
         }


### PR DESCRIPTION
There was no possibility to add Optional Parameters:
https://geocoder.opencagedata.com/api#forward-opt

Now they can be set as array:

$geocoder = new \OpenCage\Geocoder\Geocoder('API-KEY');
$result = $geocoder->geocode("Brivibas street 1, Riga",**['countrycode'=>'lv','min_confidence'=>8]**);